### PR TITLE
FIX, scroll top on navigate

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,21 +1,25 @@
-import { NgModule } from "@angular/core";
-import { RouterModule, Routes } from "@angular/router";
-import { DashboardPortafolioComponent } from "./dashboard-portafolio/dashboard-portafolio.component";
-import { HomeComponent } from "./dashboard-portafolio/pages/home/home.component";
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardPortafolioComponent } from './dashboard-portafolio/dashboard-portafolio.component';
+import { HomeComponent } from './dashboard-portafolio/pages/home/home.component';
 
-const routes : Routes =[
-
-      {
-        path: '',
-        loadChildren: ()=> import('./dashboard-portafolio/dashboard-portafolio.module').then((m)=>m.DashboardPortafolioModule)
-      },
-     {
-        path:'**',
-        redirectTo: 'home'
-      }, 
-]
+const routes: Routes = [
+  {
+    path: '',
+    loadChildren: () =>
+      import('./dashboard-portafolio/dashboard-portafolio.module').then(
+        (m) => m.DashboardPortafolioModule
+      ),
+  },
+  {
+    path: '**',
+    redirectTo: 'home',
+  },
+];
 @NgModule({
-imports:[RouterModule.forRoot(routes)],
-exports:[RouterModule]
+  imports: [
+    RouterModule.forRoot(routes, { scrollPositionRestoration: 'enabled' }), // Restaura siempre el scroll del objeto window al realizar navegacion
+  ],
+  exports: [RouterModule],
 })
-export class AppRoutingModule{}
+export class AppRoutingModule {}

--- a/src/app/dashboard-portafolio/dashboard-portafolio.component.css
+++ b/src/app/dashboard-portafolio/dashboard-portafolio.component.css
@@ -1,20 +1,23 @@
 .example-container {
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .example-sidenav-content {
-  height: 100%;
+  /* height: 100%; */
 }
 
 .example-sidenav {
   padding: 20px;
+  position: fixed;
+  top: 0;
 }
 
 
 .router-container {
   padding-top: 50px; /* Ajusta el valor según la altura del toolbar */
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  overflow-y: auto; /* Ajusta el desplazamiento vertical si es necesario */
+}
+
+
+main {
+  min-height: calc(100vh - 5rem); /* 5rem es el alto del toolbar; habria que considerar colocar el alto del toolbar en una variable CSS para establecerlo globalmente */
 }

--- a/src/app/dashboard-portafolio/dashboard-portafolio.component.html
+++ b/src/app/dashboard-portafolio/dashboard-portafolio.component.html
@@ -1,29 +1,23 @@
-
-  
- 
-  <mat-drawer-container class="example-container" autosize>
-    <mat-drawer
+<mat-drawer-container class="example-container" autosize>
+  <mat-drawer
     #drawer
     class="example-sidenav"
     mode="side"
     position="end"
-    [opened]="mostrarSidebar">
-    <app-sidebar (click)="mostrarSidebar= !mostrarSidebar"></app-sidebar>
-    </mat-drawer>
-    <div class="example-sidenav-content">
-      
-      <main>
-        <app-toolbar class="fixed-top" (click)="mostrarSidebar= !mostrarSidebar"></app-toolbar>
-        <router-outlet></router-outlet>
-        <app-footer></app-footer>
-      </main>
-
-  
-
-  
-    </div>
-  </mat-drawer-container>
-
+    [opened]="mostrarSidebar"
+  >
+    <app-sidebar (click)="mostrarSidebar = !mostrarSidebar"></app-sidebar>
+  </mat-drawer>
+  <div class="example-sidenav-content">
+    <main>
+      <app-toolbar
+        class="fixed-top"
+        (click)="mostrarSidebar = !mostrarSidebar"
+      ></app-toolbar>
+      <router-outlet></router-outlet>
+      <app-footer></app-footer>
+    </main>
+  </div>
+</mat-drawer-container>
 
 <!-- <app-footer></app-footer> -->
-

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,13 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
-/* 
+/*
 html, body { height: 100%;margin:0 } */
 /* body {display: flex;  flex-direction: column;margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; } */
 
-  main {
-    width: 100%;
-    height: 100vh; 
-    overflow-y: auto; 
-  }
 
 
 @import '~@fortawesome/fontawesome-free/css/all.css';


### PR DESCRIPTION
Hice algunos cambios en el RouterModule.forRoot

La configuracion 

`RouterModule.forRoot(routes, { scrollPositionRestoration: 'enabled' }),` Permite restaurar el scroll de window al navegar,

Tambien cambie algunos estilos de la etiqueta main, y el mat-drawer para que funcione todo correctamente